### PR TITLE
feat: ability to override default renovate connection config

### DIFF
--- a/.changeset/quick-signs-raise.md
+++ b/.changeset/quick-signs-raise.md
@@ -1,0 +1,5 @@
+---
+'@secustor/backstage-plugin-renovate-backend-module-queue-redis': patch
+---
+
+Add config override for redis-cache queue connection settings.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -26,6 +26,9 @@ renovate:
 
   queue:
     type: redis
+# Optional configuration for the Redis queue connection, overrides `backend.cache.redis.connection`
+#   redis:
+#     connection: redis://localhost:6379
 
   config:
     dryRun: full

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -26,9 +26,9 @@ renovate:
 
   queue:
     type: redis
-# Optional configuration for the Redis queue connection, overrides `backend.cache.redis.connection`
-#   redis:
-#     connection: redis://localhost:6379
+  # Optional configuration for the Redis queue connection, overrides `backend.cache.redis.connection`
+  # redis:
+  #   connection: redis://localhost:6379
 
   config:
     dryRun: full

--- a/plugins/renovate-backend-module-queue-redis/config.d.ts
+++ b/plugins/renovate-backend-module-queue-redis/config.d.ts
@@ -14,10 +14,4 @@ export interface Config {
         connection?: string;
       };
     };
-
-    /**
-     * Config for Renovate itself
-     */
-    config: JsonObject;
-  };
 }

--- a/plugins/renovate-backend-module-queue-redis/config.d.ts
+++ b/plugins/renovate-backend-module-queue-redis/config.d.ts
@@ -6,7 +6,6 @@ export interface Config {
      * Config for queue
      */
     queue: {
-
       redis?: {
         /**
          * Optional configuration for the Redis queue connection, overrides `backend.cache.redis.connection`
@@ -14,4 +13,5 @@ export interface Config {
         connection?: string;
       };
     };
+  };
 }

--- a/plugins/renovate-backend-module-queue-redis/config.d.ts
+++ b/plugins/renovate-backend-module-queue-redis/config.d.ts
@@ -6,11 +6,6 @@ export interface Config {
      * Config for queue
      */
     queue: {
-      /**
-       * The queue to use. The value references id of a queue supplied by a module
-       * For module-specific configuration sees the relevant module
-       */
-      type: string;
 
       redis?: {
         /**

--- a/plugins/renovate-backend-module-queue-redis/config.d.ts
+++ b/plugins/renovate-backend-module-queue-redis/config.d.ts
@@ -1,0 +1,28 @@
+import { JsonObject } from '@backstage/types';
+
+export interface Config {
+  renovate: {
+    /**
+     * Config for queue
+     */
+    queue: {
+      /**
+       * The queue to use. The value references id of a queue supplied by a module
+       * For module-specific configuration sees the relevant module
+       */
+      type: string;
+
+      redis?: {
+        /**
+         * Optional configuration for the Redis queue connection, overrides `backend.cache.redis.connection`
+         */
+        connection?: string;
+      };
+    };
+
+    /**
+     * Config for Renovate itself
+     */
+    config: JsonObject;
+  };
+}

--- a/plugins/renovate-backend-module-queue-redis/package.json
+++ b/plugins/renovate-backend-module-queue-redis/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.5.0",
     "@backstage/cli": "^0.33.0",
+    "@backstage/types": "^1.2.1",
     "jest-mock-extended": "^4.0.0"
   },
   "files": [

--- a/plugins/renovate-backend-module-queue-redis/src/config.ts
+++ b/plugins/renovate-backend-module-queue-redis/src/config.ts
@@ -1,7 +1,7 @@
 import { Config } from '@backstage/config';
 
 export function getCacheConfig(config: Config): string | null {
-  // Override the cache connection settings when the backstage backend is not using Redis as cache store but Redis queue is still desired
+const overrideCacheConnection = config.getOptionalString('renovate.queue.redis.connection')
   const overrideCacheConfig = config.getOptionalConfig('renovate.queue.redis');
   if (overrideCacheConfig) {
     const overrideCacheConnection =

--- a/plugins/renovate-backend-module-queue-redis/src/config.ts
+++ b/plugins/renovate-backend-module-queue-redis/src/config.ts
@@ -1,6 +1,17 @@
 import { Config } from '@backstage/config';
 
 export function getCacheConfig(config: Config): string | null {
+  // Override the cache connection settings.
+  // Used in instances where backstage backend is not using redis as cache store.
+  const overrideCacheConfig = config.getOptionalConfig('renovate.queue.redis');
+  if (overrideCacheConfig) {
+    const overrideCacheConnection =
+      overrideCacheConfig.getOptionalString('connection');
+    if (overrideCacheConnection) {
+      return overrideCacheConnection;
+    }
+  }
+
   const cacheConfig = config.getOptionalConfig('backend.cache');
   if (!cacheConfig) {
     return null;

--- a/plugins/renovate-backend-module-queue-redis/src/config.ts
+++ b/plugins/renovate-backend-module-queue-redis/src/config.ts
@@ -1,8 +1,7 @@
 import { Config } from '@backstage/config';
 
 export function getCacheConfig(config: Config): string | null {
-  // Override the cache connection settings.
-  // Used in instances where backstage backend is not using redis as cache store.
+  // Override the cache connection settings when the backstage backend is not using Redis as cache store but Redis queue is still desired
   const overrideCacheConfig = config.getOptionalConfig('renovate.queue.redis');
   if (overrideCacheConfig) {
     const overrideCacheConnection =

--- a/plugins/renovate-backend-module-queue-redis/src/config.ts
+++ b/plugins/renovate-backend-module-queue-redis/src/config.ts
@@ -1,16 +1,6 @@
 import { Config } from '@backstage/config';
 
 export function getCacheConfig(config: Config): string | null {
-const overrideCacheConnection = config.getOptionalString('renovate.queue.redis.connection')
-  const overrideCacheConfig = config.getOptionalConfig('renovate.queue.redis');
-  if (overrideCacheConfig) {
-    const overrideCacheConnection =
-      overrideCacheConfig.getOptionalString('connection');
-    if (overrideCacheConnection) {
-      return overrideCacheConnection;
-    }
-  }
-
   const cacheConfig = config.getOptionalConfig('backend.cache');
   if (!cacheConfig) {
     return null;
@@ -22,4 +12,8 @@ const overrideCacheConnection = config.getOptionalString('renovate.queue.redis.c
   }
 
   return cacheConfig.getOptionalString('connection') ?? null;
+}
+
+export function getOverrideConnection(config: Config): string | null {
+  return config.getOptionalString('renovate.queue.redis.connection') ?? null;
 }

--- a/plugins/renovate-backend-module-queue-redis/src/module.ts
+++ b/plugins/renovate-backend-module-queue-redis/src/module.ts
@@ -8,7 +8,7 @@ import {
   RunOptions,
 } from '@secustor/backstage-plugin-renovate-node';
 import { RedisQueue } from './queue';
-import { getCacheConfig } from './config';
+import { getCacheConfig, getOverrideConnection } from './config';
 
 export const renovateModuleQueueRedis = createBackendModule({
   pluginId: 'renovate',
@@ -21,7 +21,8 @@ export const renovateModuleQueueRedis = createBackendModule({
         queueEx: renovateQueueExtensionPoint,
       },
       async init({ logger, queueEx, config }) {
-        const cacheURL = getCacheConfig(config);
+        const cacheURL =
+          getOverrideConnection(config) ?? getCacheConfig(config);
         if (!cacheURL) {
           logger.warn(
             'Could not find Redis connection URL while Redis Queue module is loaded. Skipping Redis Queue init.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12696,6 +12696,7 @@ __metadata:
     "@backstage/backend-test-utils": "npm:^1.5.0"
     "@backstage/cli": "npm:^0.33.0"
     "@backstage/config": "npm:^1.3.2"
+    "@backstage/types": "npm:^1.2.1"
     "@secustor/backstage-plugin-renovate-node": "workspace:^"
     bullmq: "npm:^5.41.0"
     ioredis: "npm:^5.4.1"


### PR DESCRIPTION
resolves https://github.com/secustor/backstage-plugins/issues/819

Provides a way to override the default backstage/backend redis connection queue details. 

Used in examples of backstage not using Redis, however Renovate relies on Redis for BullMQ Implementation.