### PR TITLE
chore(renovate-backend): correct `queues` to `queue`

### DIFF
--- a/plugins/renovate-backend/config.d.ts
+++ b/plugins/renovate-backend/config.d.ts
@@ -66,7 +66,7 @@ export interface Config {
     /**
      * Config for queues
      */
-    queues: {
+    queue: {
       /**
        * The queue to use. The value references id of a queue supplied by a module
        * For module-specific configuration sees the relevant module


### PR DESCRIPTION
Fixing incorrect config definition