### PR TITLE
fix(renovate): pin material UI to 7.2.x

### DIFF
--- a/.changeset/puny-hairs-do.md
+++ b/.changeset/puny-hairs-do.md
@@ -1,0 +1,5 @@
+---
+'@secustor/backstage-plugin-renovate': patch
+---
+
+Fix theme.alpha error when using material-ui 7.3.x

--- a/plugins/renovate/package.json
+++ b/plugins/renovate/package.json
@@ -70,7 +70,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/lab": "6.0.0-beta.31",
-    "@mui/material": "^7.0.0",
+    "@mui/material": "~7.2.0",
     "@mui/styles": "^6.1.0",
     "@mui/x-data-grid": "^8.0.0",
     "@secustor/backstage-plugin-renovate-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7926,7 +7926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^7.0.0":
+"@mui/material@npm:^7.0.0, @mui/material@npm:~7.2.0":
   version: 7.2.0
   resolution: "@mui/material@npm:7.2.0"
   dependencies:
@@ -11557,7 +11557,7 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@mui/icons-material": "npm:^7.0.0"
     "@mui/lab": "npm:6.0.0-beta.31"
-    "@mui/material": "npm:^7.0.0"
+    "@mui/material": "npm:~7.2.0"
     "@mui/styles": "npm:^6.1.0"
     "@mui/x-data-grid": "npm:^8.0.0"
     "@secustor/backstage-plugin-renovate-client": "workspace:^"


### PR DESCRIPTION
Fixes an error ( `theme.alpha` not found ) when using Material UI >7.3.0